### PR TITLE
Various mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 <h1 align="center">🎮</h1>
 <h3 align="center">discord-namer</h3>
-<p align="center">Changes my Discord nickname when I'm @-mentioned, using a random emoji.<p>
+<p align="center">Changes the user's Discord nickname when they are @-mentioned, using a random emoji.<p>

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ client.on('message', msg => {
 
   const jason = msg.guild.me
   const random = nemojis.random()
-  return jason.setNickname(`${random.emoji}man`)
+  return msg.guild.me.setNickname(`${random.emoji}man`)
 })
 
 client.login(process.env.DISCORD_TOKEN)

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const client = new Discord.Client()
 
 client.on('message', msg => {
   // Do nothing if the user wasn't mentioned
-  if (!msg.mentions.users.has(client.user)) return
+  if (!msg.mentions.users.has(client.user.id)) return
   // Get a random emoji
   const random = nemojis.random()
   // Change their nickname

--- a/index.js
+++ b/index.js
@@ -2,18 +2,14 @@ require('dotenv').config()
 
 const Discord = require('discord.js')
 const nemojis = require('node-emoji')
-const get = require('get-value')
 const client = new Discord.Client()
 
 client.on('message', msg => {
-  const members = get(msg, 'mentions.members')
-  if (!members) return
+  if (!msg.mentions.users.has(client.user)) return
 
-  const jason = members.find(member => member.user.username === 'jasonetco')
-  if (!jason) return
-
+  const jason = msg.guild.me
   const random = nemojis.random()
-  return jason.setNickname(`${random.emoji}man`, `${msg.author.username} mentioned Jason, so here we are.`)
+  return jason.setNickname(`${random.emoji}man`)
 })
 
 client.login(process.env.DISCORD_TOKEN)

--- a/index.js
+++ b/index.js
@@ -5,10 +5,11 @@ const nemojis = require('node-emoji')
 const client = new Discord.Client()
 
 client.on('message', msg => {
+  // Do nothing if the user wasn't mentioned
   if (!msg.mentions.users.has(client.user)) return
-
-  const jason = msg.guild.me
+  // Get a random emoji
   const random = nemojis.random()
+  // Change their nickname
   return msg.guild.me.setNickname(`${random.emoji}man`)
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -758,14 +758,6 @@
       "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
     },
-    "get-value": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/get-value/-/get-value-3.0.1.tgz",
-      "integrity": "sha512-mKZj9JLQrwMBtj5wxi6MH8Z5eSKaERpAwjg43dPtlGI1ZVEgH/qC7T8/6R2OBSUA+zzHBZgICsVJaEIV2tKTDA==",
-      "requires": {
-        "isobject": "^3.0.1"
-      }
-    },
     "glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -989,11 +981,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
-    },
-    "isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "js-tokens": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "discord-namer",
   "version": "1.0.0",
-  "description": "",
+  "description": "https://github.com/JasonEtco/discord-namer/pull/1/files",
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
-  "author": "",
+  "author": "Jason Etcovitch <jasonetco@gmail.com>",
   "license": "ISC",
   "dependencies": {
     "discord.js": "^11.4.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "discord-namer",
   "version": "1.0.0",
-  "description": "https://github.com/JasonEtco/discord-namer/pull/1/files",
+  "description": "Changes the user's Discord nickname when they are @-mentioned, using a random emoji.",
   "main": "index.js",
   "scripts": {
     "start": "node index.js",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "discord.js": "^11.4.2",
     "dotenv": "^6.0.0",
-    "get-value": "^3.0.1",
     "node-emoji": "^1.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Remove dependency
Prevent possibility of two people with the same name being mentioned
Really shouldn't add a reason to nickname updates, you can't do that in the client and as userbots are against ToS that would show clearly it's a bot doing it.